### PR TITLE
Postgres schemas support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,6 @@ jobs:
         env:
           PYTHONPATH: .
         run: |
-          cd tests/poc/
           alembic revision --autogenerate
           alembic -x data=true -x test=true upgrade head
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
         env:
           PYTHONPATH: .
         run: |
-          PGPASSWORD=password psql -h localhost -U user -tc "CREATE SCHEMA poc;"
+          PGPASSWORD=password psql -h localhost -U user -d database -tc "CREATE SCHEMA poc;"
           alembic revision --autogenerate
           alembic -x data=true -x test=true upgrade head
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,7 @@ jobs:
         env:
           PYTHONPATH: .
         run: |
+          PGPASSWORD=password psql -U user -tc "CREATE SCHEMA poc;"
           alembic revision --autogenerate
           alembic -x data=true -x test=true upgrade head
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
         env:
           PYTHONPATH: .
         run: |
-          PGPASSWORD=password psql -U user -tc "CREATE SCHEMA poc;"
+          PGPASSWORD=password psql -h localhost -U user -tc "CREATE SCHEMA poc;"
           alembic revision --autogenerate
           alembic -x data=true -x test=true upgrade head
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+### Added
+- Database schemas support.
+### Removed
+- Root Aggregate model.
+
 ## [0.3.0] - 2021-11-16
 ### Added
 - Added base implementation of CQRS Pattern.

--- a/alembic.ini
+++ b/alembic.ini
@@ -2,7 +2,7 @@
 
 [alembic]
 # path to migration scripts
-script_location = migration_example/
+script_location = tests/poc/migration_example/
 
 # template used to generate migration files
 # file_template = %%(rev)s_%%(slug)s

--- a/kingdom_sdk/__init__.py
+++ b/kingdom_sdk/__init__.py
@@ -3,7 +3,7 @@ import os
 # Define the package's version.
 # - Is used for indexing and distributing the package
 # - Follow the conventions defined by PEP440
-__version__ = "0.3.0dev1"
+__version__ = "1.0.0dev1"
 
 
 def _get_base_dir() -> str:

--- a/kingdom_sdk/database/factories.py
+++ b/kingdom_sdk/database/factories.py
@@ -39,12 +39,6 @@ def aggregate_table_factory(
     return entity_table_factory(schema, name, *columns)
 
 
-def root_aggregate_table_factory(
-    schema: str, name: str, *columns: Column
-) -> TableFactory_T:
-    return aggregate_table_factory(schema, name, *columns)
-
-
 def relationship_table_factory(
     schema: str, name: str, *columns: Column
 ) -> TableFactory_T:

--- a/kingdom_sdk/database/factories.py
+++ b/kingdom_sdk/database/factories.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from uuid import uuid4
 
 from sqlalchemy import Boolean, Column, DateTime, Integer, Table
@@ -8,7 +9,7 @@ from kingdom_sdk.utils import time
 
 
 def entity_table_factory(
-    schema: str, name: str, *columns: Column
+    name: str, *columns: Column, schema: Optional[str] = None
 ) -> TableFactory_T:
     return lambda metadata: Table(
         name,
@@ -34,12 +35,12 @@ def entity_table_factory(
 
 
 def aggregate_table_factory(
-    schema: str, name: str, *columns: Column
+    name: str, *columns: Column, schema: Optional[str] = None
 ) -> TableFactory_T:
-    return entity_table_factory(schema, name, *columns)
+    return entity_table_factory(name, *columns, schema=schema)
 
 
 def relationship_table_factory(
-    schema: str, name: str, *columns: Column
+    name: str, *columns: Column, schema: Optional[str] = None
 ) -> TableFactory_T:
     return lambda metadata: Table(name, metadata, *columns, schema=schema)

--- a/kingdom_sdk/database/factories.py
+++ b/kingdom_sdk/database/factories.py
@@ -7,7 +7,9 @@ from kingdom_sdk.database.types import TableFactory_T
 from kingdom_sdk.utils import time
 
 
-def entity_table_factory(name: str, *columns: Column) -> TableFactory_T:
+def entity_table_factory(
+    schema: str, name: str, *columns: Column
+) -> TableFactory_T:
     return lambda metadata: Table(
         name,
         metadata,
@@ -27,18 +29,23 @@ def entity_table_factory(name: str, *columns: Column) -> TableFactory_T:
             default=time.generate_now,
         ),
         *columns,
+        schema=schema,
     )
 
 
-def aggregate_table_factory(name: str, *columns: Column) -> TableFactory_T:
-    return entity_table_factory(name, *columns)
+def aggregate_table_factory(
+    schema: str, name: str, *columns: Column
+) -> TableFactory_T:
+    return entity_table_factory(schema, name, *columns)
 
 
 def root_aggregate_table_factory(
-    name: str, *columns: Column
+    schema: str, name: str, *columns: Column
 ) -> TableFactory_T:
-    return aggregate_table_factory(name, *columns)
+    return aggregate_table_factory(schema, name, *columns)
 
 
-def relationship_table_factory(name: str, *columns: Column) -> TableFactory_T:
-    return lambda metadata: Table(name, metadata, *columns)
+def relationship_table_factory(
+    schema: str, name: str, *columns: Column
+) -> TableFactory_T:
+    return lambda metadata: Table(name, metadata, *columns, schema=schema)

--- a/kingdom_sdk/database/mappers.py
+++ b/kingdom_sdk/database/mappers.py
@@ -3,7 +3,7 @@ from typing import Any, Type
 from sqlalchemy import Table
 from sqlalchemy.orm import mapper
 
-from kingdom_sdk.domain.aggregate import Aggregate, RootAggregate
+from kingdom_sdk.domain.aggregate import Aggregate
 from kingdom_sdk.domain.entity import Entity
 
 
@@ -22,9 +22,3 @@ def aggregate_mapper(
     aggregate: Type[Aggregate], table: Table, **properties: Any
 ) -> None:
     entity_mapper(aggregate, table, **properties)
-
-
-def root_aggregate_mapper(
-    aggregate: Type[RootAggregate], table: Table, **properties: Any
-) -> None:
-    aggregate_mapper(aggregate, table, **properties)

--- a/kingdom_sdk/database/migrations.py
+++ b/kingdom_sdk/database/migrations.py
@@ -1,0 +1,48 @@
+from alembic import context
+from sqlalchemy import MetaData, create_engine
+
+from kingdom_sdk import config
+
+
+def run_migrations_offline(schema: str, metadata: MetaData) -> None:
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+    """
+    context.configure(
+        url=config.get_database_url(),
+        target_metadata=metadata,
+        literal_binds=True,
+        include_schemas=True,
+        dialect_opts={"paramstyle": "named"},
+        version_table_schema=schema,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online(schema: str, metadata: MetaData) -> None:
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+    """
+    connectable = create_engine(config.get_database_url())
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=metadata,
+            include_schemas=True,
+            version_table_schema=schema,
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()

--- a/kingdom_sdk/database/migrations.py
+++ b/kingdom_sdk/database/migrations.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from alembic import context
 from sqlalchemy import MetaData, create_engine
 
@@ -10,7 +12,9 @@ _include_object = (
 )
 
 
-def run_migrations_offline(schema: str, metadata: MetaData) -> None:
+def run_migrations_offline(
+    metadata: MetaData, schema: Optional[str] = None
+) -> None:
     """Run migrations in 'offline' mode.
 
     This configures the context with just a URL
@@ -21,21 +25,31 @@ def run_migrations_offline(schema: str, metadata: MetaData) -> None:
     Calls to context.execute() here emit the given string to the
     script output.
     """
-    context.configure(
-        url=config.get_database_url(),
-        target_metadata=metadata,
-        literal_binds=True,
-        include_schemas=True,
-        include_object=_include_object(schema),
-        dialect_opts={"paramstyle": "named"},
-        version_table_schema=schema,
-    )
+    if schema:
+        context.configure(
+            url=config.get_database_url(),
+            target_metadata=metadata,
+            literal_binds=True,
+            include_schemas=True,
+            include_object=_include_object(schema),
+            dialect_opts={"paramstyle": "named"},
+            version_table_schema=schema,
+        )
+    else:
+        context.configure(
+            url=config.get_database_url(),
+            target_metadata=metadata,
+            literal_binds=True,
+            dialect_opts={"paramstyle": "named"},
+        )
 
     with context.begin_transaction():
         context.run_migrations()
 
 
-def run_migrations_online(schema: str, metadata: MetaData) -> None:
+def run_migrations_online(
+    metadata: MetaData, schema: Optional[str] = None
+) -> None:
     """Run migrations in 'online' mode.
 
     In this scenario we need to create an Engine
@@ -44,13 +58,16 @@ def run_migrations_online(schema: str, metadata: MetaData) -> None:
     connectable = create_engine(config.get_database_url())
 
     with connectable.connect() as connection:
-        context.configure(
-            connection=connection,
-            target_metadata=metadata,
-            include_schemas=True,
-            include_object=_include_object(schema),
-            version_table_schema=schema,
-        )
+        if schema:
+            context.configure(
+                connection=connection,
+                target_metadata=metadata,
+                include_schemas=True,
+                include_object=_include_object(schema),
+                version_table_schema=schema,
+            )
+        else:
+            context.configure(connection=connection, target_metadata=metadata)
 
         with context.begin_transaction():
             context.run_migrations()

--- a/kingdom_sdk/database/migrations.py
+++ b/kingdom_sdk/database/migrations.py
@@ -3,6 +3,12 @@ from sqlalchemy import MetaData, create_engine
 
 from kingdom_sdk import config
 
+_include_object = (
+    lambda schema: lambda object, name, type, reflected, compare_to: not (
+        type == "table" and object.schema != schema
+    )
+)
+
 
 def run_migrations_offline(schema: str, metadata: MetaData) -> None:
     """Run migrations in 'offline' mode.
@@ -20,6 +26,7 @@ def run_migrations_offline(schema: str, metadata: MetaData) -> None:
         target_metadata=metadata,
         literal_binds=True,
         include_schemas=True,
+        include_object=_include_object(schema),
         dialect_opts={"paramstyle": "named"},
         version_table_schema=schema,
     )
@@ -41,6 +48,7 @@ def run_migrations_online(schema: str, metadata: MetaData) -> None:
             connection=connection,
             target_metadata=metadata,
             include_schemas=True,
+            include_object=_include_object(schema),
             version_table_schema=schema,
         )
 

--- a/kingdom_sdk/domain/aggregate.py
+++ b/kingdom_sdk/domain/aggregate.py
@@ -38,10 +38,3 @@ class Aggregate(Entity, ABC):
     @property
     def events(self) -> List[Event]:
         return self._events
-
-
-class RootAggregate(Aggregate, ABC):
-    """Base class for root aggregates.
-
-    There's only one root aggregate for each bounded context.
-    """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kingdom-sdk"
-version = "0.3.0dev1"
+version = "1.0.0dev1"
 description = "Library containing the core modules for the kingdom-python-server"
 authors = ["William Abreu <william@t10.digital>"]
 license = "MIT License"

--- a/tests/poc/context_example/orm.py
+++ b/tests/poc/context_example/orm.py
@@ -12,13 +12,16 @@ from kingdom_sdk.domain.aggregate import Aggregate
 from tests.poc.context_example import model
 
 examples_entity = entity_table_factory(
-    "examples_entity", Column("name", String(255), nullable=False)
+    "poc", "examples_entity", Column("name", String(255), nullable=False)
 )
 
 examples_aggregate = aggregate_table_factory(
+    "poc",
     "examples_aggregate",
     Column("value", Float(), nullable=False),
-    Column("reference_id", ForeignKey("examples_entity.id"), nullable=False),
+    Column(
+        "reference_id", ForeignKey("poc.examples_entity.id"), nullable=False
+    ),
 )
 
 

--- a/tests/poc/context_example/orm.py
+++ b/tests/poc/context_example/orm.py
@@ -12,16 +12,18 @@ from kingdom_sdk.domain.aggregate import Aggregate
 from tests.poc.context_example import model
 
 examples_entity = entity_table_factory(
-    "poc", "examples_entity", Column("name", String(255), nullable=False)
+    "examples_entity",
+    Column("name", String(255), nullable=False),
+    schema="poc",
 )
 
 examples_aggregate = aggregate_table_factory(
-    "poc",
     "examples_aggregate",
     Column("value", Float(), nullable=False),
     Column(
         "reference_id", ForeignKey("poc.examples_entity.id"), nullable=False
     ),
+    schema="poc",
 )
 
 

--- a/tests/poc/context_example/queries/query.sql
+++ b/tests/poc/context_example/queries/query.sql
@@ -1,6 +1,6 @@
 /*skip-formatter*/
 SELECT *
-FROM   examples_entity
+FROM   poc.examples_entity
 WHERE  id = {{ id }}
    {% if name %}
    and name ilike {{ name }}

--- a/tests/poc/migration_example/env.py
+++ b/tests/poc/migration_example/env.py
@@ -10,82 +10,41 @@ from logging.config import fileConfig
 
 from alembic import context
 from dotenv import load_dotenv
-from sqlalchemy import create_engine, engine, orm
+from sqlalchemy import orm
 
-from kingdom_sdk import config as app_config
+from kingdom_sdk.database.migrations import (
+    run_migrations_offline,
+    run_migrations_online,
+)
 from tests.poc.context_example.bootstrap import bootstrap
 
 load_dotenv()
 
-# this is the Alembic Config object, which provides
-# access to the values within the .ini file in use.
+# This is the Alembic Config object,
+# which provides access to the values within the .ini file in use.
 config = context.config
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
 fileConfig(config.config_file_name)
 
-# add your model's MetaData object here
-# for 'autogenerate' support
+# Add your model's MetaData object here.
+# For 'autogenerate' support:
 # from myapp import mymodel
 # target_metadata = mymodel.Base.metadata
 orm.clear_mappers()
 target_metadata = bootstrap()
 
+# Postgres schema name, where the "alembic_versino" table will be stored.
+SCHEMA_NAME = "poc"
 
-# other values from the config, defined by the needs of env.py,
+# Other values from the config, defined by the needs of env.py,
 # can be acquired:
 # my_important_option = config.get_main_option("my_important_option")
 # ... etc.
 
 
-def get_engine() -> engine.Engine:
-    return create_engine(app_config.get_database_url())
-
-
-def run_migrations_offline():
-    """Run migrations in 'offline' mode.
-
-    This configures the context with just a URL
-    and not an Engine, though an Engine is acceptable
-    here as well.  By skipping the Engine creation
-    we don't even need a DBAPI to be available.
-
-    Calls to context.execute() here emit the given string to the
-    script output.
-
-    """
-
-    context.configure(
-        url=app_config.get_database_url(),
-        target_metadata=target_metadata,
-        literal_binds=True,
-        dialect_opts={"paramstyle": "named"},
-    )
-
-    with context.begin_transaction():
-        context.run_migrations()
-
-
-def run_migrations_online():
-    """Run migrations in 'online' mode.
-
-    In this scenario we need to create an Engine
-    and associate a connection with the context.
-
-    """
-    connectable = get_engine()
-
-    with connectable.connect() as connection:
-        context.configure(
-            connection=connection, target_metadata=target_metadata
-        )
-
-        with context.begin_transaction():
-            context.run_migrations()
-
-
 if context.is_offline_mode():
-    run_migrations_offline()
+    run_migrations_offline(SCHEMA_NAME, target_metadata)
 else:
-    run_migrations_online()
+    run_migrations_online(SCHEMA_NAME, target_metadata)

--- a/tests/poc/migration_example/env.py
+++ b/tests/poc/migration_example/env.py
@@ -37,6 +37,6 @@ SCHEMA_NAME = "poc"
 
 
 if context.is_offline_mode():
-    run_migrations_offline(SCHEMA_NAME, target_metadata)
+    run_migrations_offline(target_metadata, SCHEMA_NAME)
 else:
-    run_migrations_online(SCHEMA_NAME, target_metadata)
+    run_migrations_online(target_metadata, SCHEMA_NAME)

--- a/tests/poc/migration_example/env.py
+++ b/tests/poc/migration_example/env.py
@@ -27,7 +27,7 @@ fileConfig(config.config_file_name)
 orm.clear_mappers()
 target_metadata = bootstrap()
 
-# Postgres schema name, where the "alembic_versino" table will be stored.
+# Postgres schema name, where the "alembic_version" table will be stored.
 SCHEMA_NAME = "poc"
 
 # Other values from the config, defined by the needs of env.py,

--- a/tests/poc/migration_example/env.py
+++ b/tests/poc/migration_example/env.py
@@ -1,11 +1,3 @@
-import os
-import sys
-from pathlib import Path
-
-# Fix the path to include repository root.
-root = Path(os.getcwd()).parent.parent
-sys.path.insert(0, root.as_posix())
-
 from logging.config import fileConfig
 
 from alembic import context


### PR DESCRIPTION
#### 📝 Description

This PR adds schema segregation support for Postgres databases, looking towards a microservices migration model.

#### 🛠️ Changes

- Added schema on orm configuration (3b5e25d)
- Removed useless root aggregate (a7f6ddf, 60a7b16)
- Added legacy support to use without schemas (22dafea)